### PR TITLE
CTC-3040 Zulip Phase 2 - Restrict Users from Changing Default Notifications

### DIFF
--- a/web/src/settings_config.ts
+++ b/web/src/settings_config.ts
@@ -777,9 +777,10 @@ export function get_notifications_table_row_data(
             throw new TypeError(`Incorrect setting_name passed: ${setting_name}`);
         }
 
+        // Disable notification settings for members and guests
         const checkbox = {
             setting_name,
-            is_disabled: false,
+            is_disabled: !page_params.is_admin && !page_params.is_owner && !page_params.is_moderator,
             is_checked: checked,
         };
         if (column === "mobile") {

--- a/web/src/settings_config.ts
+++ b/web/src/settings_config.ts
@@ -801,6 +801,7 @@ export type AllNotifications = {
     show_push_notifications_tooltip: {
         push_notifications: boolean;
         enable_online_push_notifications: boolean;
+        is_guest_or_member: boolean;
     };
 };
 
@@ -837,6 +838,7 @@ export const all_notifications = (settings_object: Settings): AllNotifications =
     show_push_notifications_tooltip: {
         push_notifications: !page_params.realm_push_notifications_enabled,
         enable_online_push_notifications: !page_params.realm_push_notifications_enabled,
+        is_guest_or_member: !page_params.is_admin && !page_params.is_owner && !page_params.is_moderator,
     },
 });
 

--- a/web/src/stream_edit.js
+++ b/web/src/stream_edit.js
@@ -169,13 +169,18 @@ export function stream_settings(sub) {
         settings_config.all_notifications(user_settings).show_push_notifications_tooltip;
 
     const settings = Object.keys(settings_labels).map((setting) => {
+        // Disable notification settings for guests
         const ret = {
             name: setting,
             label: settings_labels[setting],
-            disabled_realm_setting: check_realm_setting[setting],
-            is_disabled: check_realm_setting[setting],
+            disabled_realm_setting: page_params.is_guest || (setting == "push_notifications" && !page_params.realm_push_notifications_enabled),
+            is_disabled: page_params.is_guest || (setting == "push_notifications" && !page_params.realm_push_notifications_enabled),
             is_notification_setting: is_notification_setting(setting),
         };
+        // Disable email and wildcard notifications for members
+        if ((ret.name === "email_notifications" || ret.name === "wildcard_mentions_notify") && !page_params.is_guest) {
+            ret.disabled_realm_setting = ret.is_disabled = !page_params.is_admin && !page_params.is_owner && !page_params.is_moderator && !page_params.is_guest;
+        }
         if (is_notification_setting(setting)) {
             // This block ensures we correctly display to users the
             // current state of stream-level notification settings

--- a/web/src/stream_edit.js
+++ b/web/src/stream_edit.js
@@ -255,6 +255,7 @@ export function show_settings_for(node) {
         notification_settings,
         other_settings,
         is_admin: page_params.is_admin,
+        is_guest: page_params.is_guest,
         stream_post_policy_values: stream_data.stream_post_policy_values,
         stream_privacy_policy_values: stream_data.stream_privacy_policy_values,
         stream_privacy_policy: stream_data.get_stream_privacy_policy(stream_id),

--- a/web/templates/settings/notification_settings.hbs
+++ b/web/templates/settings/notification_settings.hbs
@@ -9,21 +9,21 @@
             <thead>
                 <tr>
                     <th rowspan="2" width="30%"></th>
-                    <th colspan="2" width="28%">{{t "Desktop"}}</th>
-                    <th rowspan="2" width="14%" class="{{#if show_push_notifications_tooltip.push_notifications}}control-label-disabled{{/if}}">
+                    <th colspan="2" width="28%" class="{{#if show_push_notifications_tooltip.is_guest_or_member}}control-label-disabled{{/if}}">{{t "Desktop"}}</th>
+                    <th rowspan="2" width="14%" class="{{#if show_push_notifications_tooltip.push_notifications}}control-label-disabled{{else if show_push_notifications_tooltip.is_guest_or_member}}control-label-disabled{{/if}}">
                         {{t "Mobile"}}
                         {{#if (not realm_push_notifications_enabled) }}
                         <i class="fa fa-question-circle settings-info-icon tippy-zulip-tooltip" data-tippy-content="{{t 'Mobile push notifications are not configured on this server.' }}"></i>
                         {{/if}}
                     </th>
-                    <th rowspan="2" width="14%">{{t "Email"}}</th>
-                    <th rowspan="2" width="14%">@all
+                    <th rowspan="2" width="14%" class="{{#if show_push_notifications_tooltip.is_guest_or_member}}control-label-disabled{{/if}}">{{t "Email"}}</th>
+                    <th rowspan="2" width="14%" class="{{#if show_push_notifications_tooltip.is_guest_or_member}}control-label-disabled{{/if}}">@all
                         <i class="fa fa-question-circle settings-info-icon tippy-zulip-tooltip" data-tippy-content="{{t 'Whether wildcard mentions like @all are treated as mentions for the purpose of notifications.' }}"></i>
                     </th>
                 </tr>
                 <tr>
-                    <th>{{t "Visual"}}</th>
-                    <th>{{t "Audible"}}</th>
+                    <th class="{{#if show_push_notifications_tooltip.is_guest_or_member}}control-label-disabled{{/if}}">{{t "Visual"}}</th>
+                    <th class="{{#if show_push_notifications_tooltip.is_guest_or_member}}control-label-disabled{{/if}}">{{t "Audible"}}</th>
                 </tr>
             </thead>
             <tbody>

--- a/web/templates/stream_settings/stream_settings.hbs
+++ b/web/templates/stream_settings/stream_settings.hbs
@@ -115,22 +115,24 @@
                         </span>
                     </div>
                 </div>
-                <h4 class="stream_setting_subsection_title">{{t "Notification settings" }}</h4>
-                <div class="subsection-parent">
-                    {{#each notification_settings}}
-                        <div class="input-group">
-                            {{> stream_settings_checkbox
-                              setting_name=name
-                              is_checked=is_checked
-                              is_muted=(lookup ../sub "is_muted")
-                              stream_id=(lookup ../sub "stream_id")
-                              notification_setting=true
-                              disabled_realm_setting=disabled_realm_setting
-                              is_disabled=is_disabled
-                              label=label}}
-                        </div>
-                    {{/each}}
-                </div>
+                {{#unless is_guest}}
+                    <h4 class="stream_setting_subsection_title">{{t "Notification settings" }}</h4>
+                    <div class="subsection-parent">
+                        {{#each notification_settings}}
+                            <div class="input-group">
+                                {{> stream_settings_checkbox
+                                  setting_name=name
+                                  is_checked=is_checked
+                                  is_muted=(lookup ../sub "is_muted")
+                                  stream_id=(lookup ../sub "stream_id")
+                                  notification_setting=true
+                                  disabled_realm_setting=disabled_realm_setting
+                                  is_disabled=is_disabled
+                                  label=label}}
+                            </div>
+                        {{/each}}
+                    </div>
+                {{/unless}}
             </div>
         </div>
 


### PR DESCRIPTION
Ticket: CTC-3040

For a guest:
![notification settings screenshot](https://github.com/DataRecognitionCorporation/drc_zulip/assets/12011073/096aabd6-83da-4479-8d85-78dd012a6707)

For a member:
![member](https://github.com/DataRecognitionCorporation/drc_zulip/assets/12011073/687d1e77-d774-47b8-9529-c1aff0c68642)

For a guest or member:
![notification triggers](https://github.com/DataRecognitionCorporation/drc_zulip/assets/12011073/d53d5fbc-cb9e-421c-834f-49edcec3a956)

This was made with the assumption that the "Normal users" in the Zulip dev environment are the same as members.  And that guests are users where `page_params.is_guest` and members are users where `page_params.is_admin`, `page_params.is_owner`, `page_params.is_moderator`, and `page_params.is_guest` are all false.  If that's not the case I will change the logic.