### PR TITLE
CTC-2942 Zulip Phase 2 - Disable User Status Personalization

### DIFF
--- a/web/src/user_card_popover.js
+++ b/web/src/user_card_popover.js
@@ -174,6 +174,7 @@ function get_user_card_popover_data(
         has_message_context,
         is_active,
         is_bot: user.is_bot,
+        is_guest_or_member: !page_params.is_admin && !page_params.is_owner && !page_params.is_moderator,
         is_me,
         is_sender_popover,
         pm_with_url: hash_util.pm_with_url(user.email),

--- a/web/templates/user_card_popover_content.hbs
+++ b/web/templates/user_card_popover_content.hbs
@@ -86,7 +86,7 @@
     {{/if}}
 
     {{#if is_me}}
-        {{#unless is_guest}}
+        {{#unless is_guest_or_member}}
         <li>
             <a tabindex="0" class="update_status_text">
                 <i class="fa fa-comments" aria-hidden="true"></i>


### PR DESCRIPTION
Ticket: https://datarecognitioncorp.atlassian.net/browse/CTC-2942

This only allows admins, owners, and moderators to set or edit their status.  Guests, members, and spectators will not see "Set a status" and will therefore be unable to personalize their status.

Admins, Owners, Moderators:
![set a status 1](https://github.com/DataRecognitionCorporation/drc_zulip/assets/12011073/587c10aa-defd-42b6-8061-7d2547b02d98)

Guests, Members, Spectators:
![set a status 2](https://github.com/DataRecognitionCorporation/drc_zulip/assets/12011073/42efd8ed-3084-485b-89e2-002e44929bef)
