### PR TITLE
CTC-2943 Zulip Phase 2 - Guest - Disable "Mark all messages read"

### DIFF
--- a/web/src/popover_menus_data.js
+++ b/web/src/popover_menus_data.js
@@ -131,6 +131,7 @@ export function get_topic_popover_content_context({stream_id, topic_name, url}) 
         can_rename_topic,
         is_realm_admin: page_params.is_admin,
         is_guest: page_params.is_guest,
+        is_not_guest_or_member: page_params.is_admin || page_params.is_owner || page_params.is_moderator,
         topic_is_resolved: resolved_topic.is_resolved(topic_name),
         color: sub.color,
         has_starred_messages,

--- a/web/src/stream_popover.js
+++ b/web/src/stream_popover.js
@@ -14,6 +14,7 @@ import * as dropdown_widget from "./dropdown_widget";
 import * as hash_util from "./hash_util";
 import {$t, $t_html} from "./i18n";
 import * as message_edit from "./message_edit";
+import {page_params} from "./page_params";
 import * as popover_menus from "./popover_menus";
 import {left_sidebar_tippy_options} from "./popover_menus";
 import * as popovers from "./popovers";

--- a/web/src/stream_popover.js
+++ b/web/src/stream_popover.js
@@ -116,6 +116,7 @@ function build_stream_popover(opts) {
 
     popovers.hide_all_except_sidebars();
     const content = render_stream_sidebar_actions({
+        is_not_guest_or_member: page_params.is_admin || page_params.is_owner || page_params.is_moderator,
         stream: sub_store.get(stream_id),
     });
 

--- a/web/src/ui_init.js
+++ b/web/src/ui_init.js
@@ -191,6 +191,7 @@ function initialize_left_sidebar() {
     const rendered_sidebar = render_left_sidebar({
         is_admin: page_params.is_admin,
         is_guest: page_params.is_guest,
+        is_not_guest_or_member: page_params.is_admin || page_params.is_owner || page_params.is_moderator,
         development_environment: page_params.development_environment,
     });
 

--- a/web/templates/left_sidebar.hbs
+++ b/web/templates/left_sidebar.hbs
@@ -11,7 +11,9 @@
                     <span class="global-filter-name">{{t 'All messages' }}</span>
                     <span class="unread_count"></span>
                 </a>
+                {{#if is_not_guest_or_member}}
                 <span class="arrow sidebar-menu-icon all-messages-sidebar-menu-icon hidden-for-spectators"><i class="zulip-icon zulip-icon-more-vertical" aria-hidden="true"></i></span>
+                {{/if}}
             </li>
             <li class="top_left_inbox top_left_row hidden-for-spectators">
                 <a href="#inbox" class="tippy-left-sidebar-tooltip global-filter-container" data-tooltip-template-id="inbox-tooltip-template">

--- a/web/templates/stream_sidebar_actions.hbs
+++ b/web/templates/stream_sidebar_actions.hbs
@@ -30,12 +30,14 @@
             {{/if}}
         </a>
     </li>
+    {{#if is_not_guest_or_member}}
     <li class="hidden-for-spectators">
         <a tabindex="0" class="mark_stream_as_read">
             <i class="fa fa-book" aria-hidden="true"></i>
             {{t "Mark all messages as read"}}
         </a>
     </li>
+    {{/if}}
 
     {{#if is_realm_admin}}
     <li class="hidden-for-spectators">

--- a/web/templates/topic_sidebar_actions.hbs
+++ b/web/templates/topic_sidebar_actions.hbs
@@ -76,12 +76,14 @@
     </li>
     {{/if}}
 
+    {{#if is_not_guest_or_member}}
     <li class="hidden-for-spectators">
         <a tabindex="0" class="sidebar-popover-mark-topic-read" data-stream-id="{{ stream_id }}" data-topic-name="{{ topic_name }}">
             <i class="fa fa-book" aria-hidden="true"></i>
             {{t "Mark all messages as read"}}
         </a>
     </li>
+    {{/if}}
 
     <li>
         <a tabindex="0" class="sidebar-popover-copy-link-to-topic" data-stream-id="{{ stream_id }}" data-topic-name="{{ topic_name }}" data-clipboard-text="{{ url }}">


### PR DESCRIPTION
Ticket: https://datarecognitioncorp.atlassian.net/browse/CTC-2943

This removes the "Mark all messages as read" options from guests and members:

Guests, Members:
![all messages 1](https://github.com/DataRecognitionCorporation/drc_zulip/assets/12011073/90f7a624-e133-49dd-88e3-71012446644d)
![streams 1](https://github.com/DataRecognitionCorporation/drc_zulip/assets/12011073/4c9d95e3-5ced-44ae-bf4f-6ef28ac32fcf)
![topic 1](https://github.com/DataRecognitionCorporation/drc_zulip/assets/12011073/f30b828f-ddd2-4c11-9fd4-73b9ecd5f48a)

Owners, Admins, Moderators:
![all messages 2](https://github.com/DataRecognitionCorporation/drc_zulip/assets/12011073/19f97e47-ed8a-423c-83fe-fa125fcdca42)
![streams 2](https://github.com/DataRecognitionCorporation/drc_zulip/assets/12011073/8f733679-071f-4be7-bebb-c510964e6cab)
![topic 2](https://github.com/DataRecognitionCorporation/drc_zulip/assets/12011073/3985bbbc-397e-4656-be06-87a77ad220da)
