### PR TITLE
CTC-2939 Zulip Phase 2 - Buddy List - Hide Admins

### DIFF
--- a/web/src/activity.js
+++ b/web/src/activity.js
@@ -91,7 +91,7 @@ export function redraw_user(user_id) {
     if (page_params.realm_presence_disabled) {
         return;
     }
-    
+
     if(page_params.is_guest && buddy_list.keys != 0 && !buddy_list.keys.includes(user_id)) {
       return;
     }

--- a/web/src/buddy_data.js
+++ b/web/src/buddy_data.js
@@ -89,10 +89,11 @@ export function sort_users(user_ids) {
     user_ids.sort(compare_function);
     // Order the roles in descending order: Current user, then guest, then member, then anything else
     const current_user = user_ids[0];
-    if (people.maybe_get_user_by_id(current_user).role >= 400) {
-        user_ids = user_ids.slice(1).sort((a, b) => parseFloat(people.maybe_get_user_by_id(b).role) - parseFloat(people.maybe_get_user_by_id(a).role));
-        user_ids.splice(0, 0, current_user);
-    }
+    // Uncomment the if statement below to only order the roles for guests and members
+    //if (people.maybe_get_user_by_id(current_user).role >= 400) {
+    user_ids = user_ids.slice(1).sort((a, b) => parseFloat(people.maybe_get_user_by_id(b).role) - parseFloat(people.maybe_get_user_by_id(a).role));
+    user_ids.splice(0, 0, current_user);
+    //}
 
     return user_ids;
 }

--- a/web/src/buddy_data.js
+++ b/web/src/buddy_data.js
@@ -87,6 +87,13 @@ export function compare_function(a, b) {
 export function sort_users(user_ids) {
     // TODO sort by unread count first, once we support that
     user_ids.sort(compare_function);
+    // Order the roles in descending order: Current user, then guest, then member, then anything else
+    const current_user = user_ids[0];
+    if (people.maybe_get_user_by_id(current_user).role >= 400) {
+        user_ids = user_ids.slice(1).sort((a, b) => parseFloat(people.maybe_get_user_by_id(b).role) - parseFloat(people.maybe_get_user_by_id(a).role));
+        user_ids.splice(0, 0, current_user);
+    }
+
     return user_ids;
 }
 
@@ -217,13 +224,8 @@ export function get_item(user_id) {
 }
 
 export function get_items_for_users(user_ids) {
-    let user_info = user_ids.map((user_id) => info_for(user_id));
-    // If the user is a guest or member then hide all admins and owners from the buddy list
-    if (!page_params.is_admin && !page_params.is_owner && !page_params.is_moderator) {
-        user_info = user_info.filter((user) => !user.is_admin && !user.is_owner);
-    }
+    const user_info = user_ids.map((user_id) => info_for(user_id));
     compose_fade_users.update_user_info(user_info, fade_config);
-
     return user_info;
 }
 

--- a/web/src/buddy_data.js
+++ b/web/src/buddy_data.js
@@ -90,10 +90,10 @@ export function sort_users(user_ids) {
     // Order the roles in descending order: Current user, then guest, then member, then anything else
     const current_user = user_ids[0];
     // Uncomment the if statement below to only order the roles for guests and members
-    //if (people.maybe_get_user_by_id(current_user).role >= 400) {
-    user_ids = user_ids.slice(1).sort((a, b) => parseFloat(people.maybe_get_user_by_id(b).role) - parseFloat(people.maybe_get_user_by_id(a).role));
-    user_ids.splice(0, 0, current_user);
-    //}
+    if (people.maybe_get_user_by_id(current_user).role >= 400) {
+        user_ids = user_ids.slice(1).sort((a, b) => parseFloat(people.maybe_get_user_by_id(b).role) - parseFloat(people.maybe_get_user_by_id(a).role));
+        user_ids.splice(0, 0, current_user);
+    }
 
     return user_ids;
 }

--- a/web/src/buddy_data.js
+++ b/web/src/buddy_data.js
@@ -96,9 +96,6 @@ function get_num_unread(user_id) {
 
 export function user_last_seen_time_status(user_id) {
     const status = presence.get_status(user_id);
-    if (status === "active") {
-        return $t({defaultMessage: "Active now"});
-    }
 
     if (status === "idle") {
         // When we complete our presence API rewrite to have the data
@@ -221,9 +218,9 @@ export function get_item(user_id) {
 
 export function get_items_for_users(user_ids) {
     let user_info = user_ids.map((user_id) => info_for(user_id));
-    // If the user is a guest or member then hide all admins from the buddy list
+    // If the user is a guest or member then hide all admins and owners from the buddy list
     if (!page_params.is_admin && !page_params.is_owner && !page_params.is_moderator) {
-        user_info = user_info.filter((user) => !user.is_admin);
+        user_info = user_info.filter((user) => !user.is_admin && !user.is_owner);
     }
     compose_fade_users.update_user_info(user_info, fade_config);
 

--- a/web/src/buddy_data.js
+++ b/web/src/buddy_data.js
@@ -220,8 +220,13 @@ export function get_item(user_id) {
 }
 
 export function get_items_for_users(user_ids) {
-    const user_info = user_ids.map((user_id) => info_for(user_id));
+    let user_info = user_ids.map((user_id) => info_for(user_id));
+    // If the user is a guest or member then hide all admins from the buddy list
+    if (!page_params.is_admin && !page_params.is_owner && !page_params.is_moderator) {
+        user_info = user_info.filter((user) => !user.is_admin);
+    }
     compose_fade_users.update_user_info(user_info, fade_config);
+
     return user_info;
 }
 

--- a/web/src/stream_list.js
+++ b/web/src/stream_list.js
@@ -35,7 +35,6 @@ import {
     StreamSidebar,
     build_stream_folder
 } from "./stream_list_drc"
-import { sorted_user_ids } from "./stream_create_subscribers_data";
 
 export let stream_cursor;
 

--- a/web/src/stream_list.js
+++ b/web/src/stream_list.js
@@ -8,6 +8,7 @@ import render_stream_subheader from "../templates/streams_subheader.hbs";
 import render_subscribe_to_more_streams from "../templates/subscribe_to_more_streams.hbs";
 
 import * as activity from "./activity";
+import * as buddy_data from "./buddy_data";
 import * as blueslip from "./blueslip";
 import * as hash_util from "./hash_util";
 import {$t} from "./i18n";
@@ -34,6 +35,7 @@ import {
     StreamSidebar,
     build_stream_folder
 } from "./stream_list_drc"
+import { sorted_user_ids } from "./stream_create_subscribers_data";
 
 export let stream_cursor;
 
@@ -621,7 +623,7 @@ export function update_stream_sidebar_for_narrow(filter) {
 
     if(page_params.is_guest && is_private){
       let user_ids = get_subscribers(stream_id);
-      activity.drc_build_user_sidebar(user_ids);
+      activity.drc_build_user_sidebar(buddy_data.sort_users(user_ids));
     } else if(page_params.is_guest && !is_private){
       activity.drc_build_user_sidebar(0);
     }


### PR DESCRIPTION
Ticket: https://datarecognitioncorp.atlassian.net/browse/CTC-2939

~~This hides admins and owners from the Buddy List if the user is a guest or member.~~  This now orders the Buddy List by current user, then guests, then members, then everyone else.  ~~It only does that if the current user is a guest or member.~~  It also updates the last active status to be more precise.

Polonius the guest and then all the members are shown.  Admins and owners are at the end of the list:
![new user list](https://github.com/DataRecognitionCorporation/drc_zulip/assets/12011073/a9a31c22-a7e3-4151-9ee7-bb49307ccf7d)


Admin, Owner, Moderator (Normal order):
![old user list](https://github.com/DataRecognitionCorporation/drc_zulip/assets/12011073/9d5e3687-b123-42d2-a144-ad2ec89dc138)


Old Last Active Status (green always will say active now):
![last active 2](https://github.com/DataRecognitionCorporation/drc_zulip/assets/12011073/5b021e28-1eb0-442b-9305-2ebb8c3b2078)

New Last Active Status (green will say last active time):
![last active 1](https://github.com/DataRecognitionCorporation/drc_zulip/assets/12011073/ed5ec068-cb46-4214-b344-830062f2dab8)

If you add an admin user with a name prefixed with -- it will show up as the first admin:
![available tech support](https://github.com/DataRecognitionCorporation/drc_zulip/assets/12011073/5add3a9d-f8ee-4f2f-87de-31f91b9e7981)

