### PR TITLE
CTC-2911 Zulip Phase 2a - Visibility of activity by group

### DIFF
--- a/web/src/resize.js
+++ b/web/src/resize.js
@@ -41,7 +41,7 @@ function get_new_heights() {
         ($("#user_search_section").outerHeight(true) ?? 0) -
         right_sidebar_shortcuts_height;
 
-    res.buddy_list_wrapper_max_height = Math.max(80, usable_height);
+    res.buddy_list_wrapper_max_height = Math.max(80, Math.floor(usable_height / 2));
 
     return res;
 }

--- a/web/src/resize.js
+++ b/web/src/resize.js
@@ -13,7 +13,6 @@ import { page_params } from "./page_params";
 import * as popovers from "./popovers";
 import * as util from "./util";
 
-
 function get_bottom_whitespace_height() {
     return message_viewport.height() * 0.4;
 }

--- a/web/src/resize.js
+++ b/web/src/resize.js
@@ -9,8 +9,10 @@ import * as message_lists from "./message_lists";
 import * as message_viewport from "./message_viewport";
 import * as navbar_alerts from "./navbar_alerts";
 import * as navigate from "./navigate";
+import { page_params } from "./page_params";
 import * as popovers from "./popovers";
 import * as util from "./util";
+
 
 function get_bottom_whitespace_height() {
     return message_viewport.height() * 0.4;
@@ -41,8 +43,13 @@ function get_new_heights() {
         ($("#user_search_section").outerHeight(true) ?? 0) -
         right_sidebar_shortcuts_height;
 
-    res.buddy_list_wrapper_max_height = Math.max(80, Math.floor(usable_height / 2));
-
+    // If user is member then restrict scroll bar height to make it easier to see each
+    // user's activity status
+    if (!page_params.is_admin && !page_params.is_owner && !page_params.is_moderator && !page_params.is_guest) {
+        res.buddy_list_wrapper_max_height = Math.max(80, Math.floor(usable_height / 2));
+    } else {
+        res.buddy_list_wrapper_max_height = Math.max(80, usable_height);
+    }
     return res;
 }
 


### PR DESCRIPTION
Ticket: https://datarecognitioncorp.atlassian.net/browse/CTC-2911

This ticket was a little vague, but since the goal is to make it easier for members to see other users and it was suggested I restrict the size of the buddy list, that's what I did.  You can still scroll to all of the users and highlight and click on them like normal, just the scrollbar area has been reduced by half.

Members (half size):
![buddy list half](https://github.com/DataRecognitionCorporation/drc_zulip/assets/12011073/093bcee6-16bf-4a3e-a837-08ffdad31009)

Admin, Owner, Moderator (normal size):
![buddy list full](https://github.com/DataRecognitionCorporation/drc_zulip/assets/12011073/5c34c89d-2017-4606-bb5f-1a0df376721a)
