### PR TITLE
Add BlockClientsMiddleware to reject ZulipMobile

### DIFF
--- a/zerver/middleware.py
+++ b/zerver/middleware.py
@@ -363,6 +363,43 @@ class LogRequests(MiddlewareMixin):
         return response
 
 
+class BlockClientsMiddleware(MiddlewareMixin):
+    """Reject requests from client applications listed in BLOCKED_CLIENT_NAMES.
+
+    This middleware must run after LogRequests, which parses the User-Agent
+    header into request_notes.client_name. Blocked clients receive an
+    immediate 403 JSON response before any authentication is attempted.
+    """
+
+    def process_request(self, request: HttpRequest) -> HttpResponse | None:
+        request_notes = RequestNotes.get_notes(request)
+        client_name = request_notes.client_name
+
+        if not settings.BLOCKED_CLIENT_NAMES:
+            return None
+
+        # Check the parsed client name (set by LogRequests from User-Agent or
+        # the explicit "client" request parameter).
+        if client_name is not None and client_name in settings.BLOCKED_CLIENT_NAMES:
+            return json_response(
+                res_type="error",
+                msg="Access denied: this client application is not permitted.",
+                status=403,
+            )
+
+        # Also check the raw User-Agent header directly, in case the client
+        # parameter was overridden to bypass the parsed client_name.
+        user_agent = request.headers.get("User-Agent", "")
+        if any(blocked in user_agent for blocked in settings.BLOCKED_CLIENT_NAMES):
+            return json_response(
+                res_type="error",
+                msg="Access denied: this client application is not permitted.",
+                status=403,
+            )
+
+        return None
+
+
 class JsonErrorHandler(MiddlewareMixin):
     def process_exception(self, request: HttpRequest, exception: Exception) -> HttpResponse | None:
         if isinstance(exception, MissingAuthenticationError):

--- a/zproject/computed_settings.py
+++ b/zproject/computed_settings.py
@@ -233,6 +233,7 @@ MIDDLEWARE = [
     # be counted in the LogRequests instrumentation of how time was
     # spent while processing a request.
     "zerver.middleware.LogRequests",
+    "zerver.middleware.BlockClientsMiddleware",
     "zerver.middleware.JsonErrorHandler",
     "zerver.middleware.RateLimitMiddleware",
     "zerver.middleware.FlushDisplayRecipientCache",

--- a/zproject/default_settings.py
+++ b/zproject/default_settings.py
@@ -670,3 +670,8 @@ ALLOW_GROUP_VALUED_SETTINGS = False
 # notification to a stream and also delete the previous counter
 # notification.
 RESOLVE_TOPIC_UNDO_GRACE_PERIOD_SECONDS = 60
+
+# Client names (as parsed from User-Agent) that should be blocked
+# from accessing the server entirely. Requests from these clients
+# receive a 403 response before authentication is attempted.
+BLOCKED_CLIENT_NAMES: set[str] = {"ZulipMobile"}


### PR DESCRIPTION
## Summary

Adds a Django middleware that blocks requests from specific client applications (ZulipMobile by default) at the application level, before authentication is attempted.

## Changes

- **zerver/middleware.py**: New BlockClientsMiddleware class
- **zproject/default_settings.py**: New BLOCKED_CLIENT_NAMES setting
- **zproject/computed_settings.py**: Registered middleware after LogRequests

## How it works

1. LogRequests parses User-Agent into request_notes.client_name
2. BlockClientsMiddleware checks that name against the blocklist
3. Also checks raw User-Agent header to prevent bypass via client POST param
4. Returns 403 JSON response for blocked clients