### PR TITLE
Wrap Deploy manifest stage with drc_assumeRole

### DIFF
--- a/jenkins/ci/Jenkinsfile
+++ b/jenkins/ci/Jenkinsfile
@@ -76,11 +76,15 @@ pipeline{
       steps{
         dir("${WORKSPACE}/${WORKING_DIR}") {
           container('aws-cli') {
-            getAWSConfig()
+            drc_assumeRole(accountNumber: aws_account, region: "us-east-2") {
+              getAWSConfig()
+            }
           }
           container('dind'){
-            dockerTag()
-            deployManifest()
+            drc_assumeRole(accountNumber: aws_account, region: "us-east-2") {
+              dockerTag()
+              deployManifest()
+            }
           }
         }
       }


### PR DESCRIPTION
Adds `drc_assumeRole` to the Deploy manifest stage so ECR auth is available for docker tag and manifest push operations.