### PR TITLE
Fix aws_account scoping in Deploy manifest stage

### DIFF
--- a/jenkins/ci/Jenkinsfile
+++ b/jenkins/ci/Jenkinsfile
@@ -76,14 +76,28 @@ pipeline{
       steps{
         dir("${WORKSPACE}/${WORKING_DIR}") {
           container('aws-cli') {
-            drc_assumeRole(accountNumber: aws_account, region: "us-east-2") {
-              getAWSConfig()
+            script {
+              def aws_account = ''
+              configFileProvider([configFile(fileId: 'settings', variable: 'settings')]) {
+                def jsonData = readJSON file: "$settings"
+                aws_account = jsonData.aws_account_number
+              }
+              drc_assumeRole(accountNumber: aws_account, region: "us-east-2") {
+                getAWSConfig()
+              }
             }
           }
           container('dind'){
-            drc_assumeRole(accountNumber: aws_account, region: "us-east-2") {
-              dockerTag()
-              deployManifest()
+            script {
+              def aws_account = ''
+              configFileProvider([configFile(fileId: 'settings', variable: 'settings')]) {
+                def jsonData = readJSON file: "$settings"
+                aws_account = jsonData.aws_account_number
+              }
+              drc_assumeRole(accountNumber: aws_account, region: "us-east-2") {
+                dockerTag()
+                deployManifest()
+              }
             }
           }
         }


### PR DESCRIPTION
The Deploy manifest stage referenced `aws_account` without defining it, causing `MissingPropertyException`. Now reads the account number from the managed settings config file within each container's script scope before calling `drc_assumeRole`, matching the Build stage pattern.