### PR TITLE
Consolidate client blocking with ISLAND exemption

### DIFF
--- a/zerver/middleware.py
+++ b/zerver/middleware.py
@@ -369,14 +369,24 @@ class BlockClientsMiddleware(MiddlewareMixin):
     This middleware must run after LogRequests, which parses the User-Agent
     header into request_notes.client_name. Blocked clients receive an
     immediate 403 JSON response before any authentication is attempted.
+
+    The ISLAND corporate secure browser is explicitly exempted, even if the
+    underlying User-Agent contains a blocked substring (e.g. "iPhone", "Android").
     """
 
     def process_request(self, request: HttpRequest) -> HttpResponse | None:
-        request_notes = RequestNotes.get_notes(request)
-        client_name = request_notes.client_name
-
         if not settings.BLOCKED_CLIENT_NAMES:
             return None
+
+        user_agent = request.headers.get("User-Agent", "")
+
+        # ISLAND corporate secure browser is always allowed through,
+        # even if its User-Agent contains blocked substrings.
+        if "ISLAND" in user_agent.upper():
+            return None
+
+        request_notes = RequestNotes.get_notes(request)
+        client_name = request_notes.client_name
 
         # Check the parsed client name (set by LogRequests from User-Agent or
         # the explicit "client" request parameter).
@@ -389,7 +399,6 @@ class BlockClientsMiddleware(MiddlewareMixin):
 
         # Also check the raw User-Agent header directly, in case the client
         # parameter was overridden to bypass the parsed client_name.
-        user_agent = request.headers.get("User-Agent", "")
         if any(blocked in user_agent for blocked in settings.BLOCKED_CLIENT_NAMES):
             return json_response(
                 res_type="error",

--- a/zerver/views/auth.py
+++ b/zerver/views/auth.py
@@ -848,16 +848,6 @@ class TwoFactorLoginView(BaseTwoFactorLoginView):
             return super().done(form_list, **kwargs)
 
 
-def block_user_agent(user_agent: str) -> bool:
-    if not hasattr(settings, "BLOCKED_USER_AGENTS"):
-        return False
-    upperUserAgents = [x.upper() for x in settings.BLOCKED_USER_AGENTS]
-    for upperUserAgent in upperUserAgents:
-        if(upperUserAgent in user_agent.upper() and "ISLAND" not in user_agent.upper()):
-            return True
-    return False
-
-
 @has_request_variables
 def login_page(
     request: HttpRequest,
@@ -865,13 +855,6 @@ def login_page(
     next: str = REQ(default="/"),
     **kwargs: Any,
 ) -> HttpResponse:
-    if(block_user_agent(request.headers.get("User-Agent", ""))):
-        return render(
-            HttpResponse(status=403),
-            '/zerver/drc_login_error.html',
-            {}
-        )
-
     if get_subdomain(request) == settings.SOCIAL_AUTH_SUBDOMAIN:
         return social_auth_subdomain_login_page(request)
 
@@ -1131,9 +1114,6 @@ def check_server_incompatibility(request: HttpRequest) -> bool:
 @require_safe
 @csrf_exempt
 def api_get_server_settings(request: HttpRequest) -> HttpResponse:
-    if(block_user_agent(request.headers.get("User-Agent", ""))):
-        return HttpResponse(status=403)
-
     # Log which client is making this request.
     process_client(request)
     result = dict(

--- a/zproject/default_settings.py
+++ b/zproject/default_settings.py
@@ -674,4 +674,5 @@ RESOLVE_TOPIC_UNDO_GRACE_PERIOD_SECONDS = 60
 # Client names (as parsed from User-Agent) that should be blocked
 # from accessing the server entirely. Requests from these clients
 # receive a 403 response before authentication is attempted.
-BLOCKED_CLIENT_NAMES: set[str] = {"ZulipMobile"}
+# The ISLAND corporate browser is always exempted regardless of this list.
+BLOCKED_CLIENT_NAMES: set[str] = {"ZulipMobile", "ZulipElectron", "Android", "iPhone", "iPad"}

--- a/zproject/dev_settings.py
+++ b/zproject/dev_settings.py
@@ -6,12 +6,6 @@ from zproject.settings_types import SCIMConfigDict
 
 ZULIP_ADMINISTRATOR = "desdemona+admin@zulip.com"
 EDIRECT_REDIRECT = "https://www.google.com"
-BLOCKED_USER_AGENTS = [
-    "ZulipElectron",
-    "Android",
-    "iPhone",
-    "iPad"
-]
 
 # Initiatize TEST_SUITE early, so other code can rely on the setting.
 TEST_SUITE = os.getenv("ZULIP_TEST_SUITE") == "true"


### PR DESCRIPTION
## Summary

Consolidates the two separate client-blocking mechanisms into one: `BlockClientsMiddleware`.

## Changes

- **BLOCKED_CLIENT_NAMES** now includes all previously blocked agents: `ZulipMobile`, `ZulipElectron`, `Android`, `iPhone`, `iPad`
- **ISLAND exemption** added to middleware — if `ISLAND` appears in the User-Agent (case-insensitive), the request is allowed through regardless of other blocked strings
- **Removed** `block_user_agent()` function and its calls from `zerver/views/auth.py`
- **Removed** `BLOCKED_USER_AGENTS` from `zproject/dev_settings.py`

## Why

Previously client blocking was split across two mechanisms with different scopes. Now it's all in one middleware that runs on every request, with the ISLAND corporate browser properly exempted.